### PR TITLE
Feature optional empty line

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
           "default": "",
           "description": "Fill in with any valid MomentJs format (either explicit or locale) to include the date tag.\nFormats can include time as well.\nLeave empty to disable."
         },
+        "jsdoc-generator.emptyLineAfterHeader": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Add empty line after header (description, date, author)."
+        },
         "jsdoc-generator.includeTypes": {
           "type": "boolean",
           "default": "true",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
           "default": "true",
           "description": "Add empty line after header (description, date, author)."
         },
+        "jsdoc-generator.singleLineComments": {
+          "type": "boolean",
+          "default": "false",
+          "description": "Generate single line comments (/** ... */) instead of always multiple lines."
+        },
         "jsdoc-generator.includeTypes": {
           "type": "boolean",
           "default": "true",

--- a/src/JsdocBuilder.ts
+++ b/src/JsdocBuilder.ts
@@ -472,19 +472,19 @@ export class JsdocBuilder {
    * @param {?NodeType} type
    */
   private async buildDescription(nodeText?: string, description?: string, type?: NodeType) {
-    this.jsdoc.appendText(' * ');
     const placeholder = getConfig('descriptionPlaceholder', '');
     if (description) {
-      this.jsdoc.appendText(this.sanitize(description));
+      this.jsdoc.appendText(` * ${this.sanitize(description)}\n`);
     } else if (placeholder) {
+      this.jsdoc.appendText(' * ');
       this.jsdoc.appendPlaceholder(placeholder);
+      this.jsdoc.appendText('\n');
     } else if (nodeText && type) {
       const autoDescription = await GenerativeAPI.describeSnippet(nodeText, type);
       if (autoDescription) {
-        this.jsdoc.appendText(this.sanitize(autoDescription));
+        this.jsdoc.appendText(` * ${this.sanitize(autoDescription)}\n`);
       }
     }
-    this.jsdoc.appendText('\n');
   }
 
   /**

--- a/src/JsdocBuilder.ts
+++ b/src/JsdocBuilder.ts
@@ -542,6 +542,9 @@ export class JsdocBuilder {
     if (this.jsdoc.value.startsWith('/**\n *\n') && (this.jsdoc.value.match(/\n/g) || []).length > 2) {
       this.jsdoc.value = this.jsdoc.value.substring(0, 4) + this.jsdoc.value.substring(7);
     }
+    if (getConfig("singleLineComments", false)) {
+      this.jsdoc.value = this.jsdoc.value.replace(/^\/\*\*\n \* ?(.*)\n$/, '/** $1');
+    }
     this.jsdoc.appendText(' */\n');
   }
 

--- a/src/JsdocBuilder.ts
+++ b/src/JsdocBuilder.ts
@@ -251,7 +251,9 @@ export class JsdocBuilder {
     }
     this.buildDate();
     this.buildAuthor();
-    this.buildJsdocLine();
+    if (getConfig('emptyLineAfterHeader', true)) {
+      this.buildJsdocLine();
+    }
     this.buildJsdocLine('constructor');
     this.buildJsdocModifiers(node.modifiers);
     await this.buildJsdocParameters(node.getFullText(), node.parameters);
@@ -455,7 +457,9 @@ export class JsdocBuilder {
     }
     this.buildDate();
     this.buildAuthor();
-    this.buildJsdocLine();
+    if (getConfig('emptyLineAfterHeader', true)) {
+      this.buildJsdocLine();
+    }
   }
 
   /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,6 +101,12 @@ interface Configuration {
    */
   dateFormat: string;
   /**
+   * Empty line after header.
+   *
+   * @type {string}
+   */
+  emptyLineAfterHeader: boolean;
+  /**
    * Whether to include types in JSDocs.
    *
    * @type {boolean}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -107,6 +107,12 @@ interface Configuration {
    */
   emptyLineAfterHeader: boolean;
   /**
+   * Generate single line comments instead of always multiple lines.
+   *
+   * @type {boolean}
+   */
+  singleLineComments: boolean;
+  /**
    * Whether to include types in JSDocs.
    *
    * @type {boolean}


### PR DESCRIPTION
Adds options for:
- `emptyLineAfterHeader=true`: Add empty line after header (description, date, author).
- `singleLineComments=false`: Generate single line comments instead of always multiple lines, `/** foo */` instead of
  ```js
  /**
   * foo
   */
  ```
Fixes:
- empty description not disabling the description line, showing an empty line: ` * `